### PR TITLE
 Rename bids_offers occurences to 'orders'

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ by overriding the corresponding methods.
 - when a new tick has started, the `on_tick` method is called
 - when the simulation has finished, the `on_finish` method is called
 - when any event arrives, the `on_event_or_response` method is called
-- When the open offers/bids response is returned, the `on_offers_bids_response` method is called
+- When the open offers/bids response is returned, the `on_orders_response` method is called
 - When the posted recommendations response is returned, the `on_matched_recommendations_response` method is called
 ---
 
@@ -106,7 +106,7 @@ The constructor of the API class can connect and register automatically to a run
     ```python
       from gsy_myco_sdk.matchers.base_matcher import BaseMatcher
       matching_client = BaseMatcher()
-      matching_client.request_offers_bids(filters={}) 
+      matching_client.request_orders(filters={}) 
       ```
     ```
     
@@ -114,18 +114,18 @@ The constructor of the API class can connect and register automatically to a run
     - `markets`: list of market ids, only fetch bids/offers in these markets (If not provided, all markets are included). 
     - `energy_type`: energy type of offers to be returned.
           
-    The bids_offers response can be received in the method named `on_offers_bids_response`, this one can be overridden to decide the recommendations algorithm and fires a call to submit_matches()
+    The orders' response can be received in the method named `on_orders_response`, this one can be overridden to decide the recommendations algorithm and fires a call to submit_matches()
 
   
-- Posts the trading bid/offer pairs recommendations back to GSy Exchange, can be called from the overridden on_offers_bids_response:
+- Posts the trading bid/offer pairs recommendations back to GSy Exchange, can be called from the overridden on_orders_response:
 
     ```python
-    def on_offers_bids_response(self, data):
+    def on_orders_response(self, data):
       """
       Posted recommendations should be in the format: 
       [BidOfferMatch.serializable_dict(), BidOfferMatch.serializable_dict()]
       """
-      bids_offers = data.get("bids_offers")
-      recommendations = my_custom_matching_algorithm(bids_offers)
+      orders = data.get("orders")
+      recommendations = my_custom_matching_algorithm(orders)
       self.submit_matches(recommended_matches=recommendations)
     ```

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The constructor of the API class can connect and register automatically to a run
     def on_orders_response(self, data):
       """
       Posted recommendations should be in the format: 
-      [BidOfferMatch.serializable_dict(), BidOfferMatch.serializable_dict()]
+      [OrdersMatch.serializable_dict(), OrdersMatch.serializable_dict()]
       """
       orders = data.get("orders")
       recommendations = my_custom_matching_algorithm(orders)

--- a/gsy_myco_sdk/matchers/base_matcher.py
+++ b/gsy_myco_sdk/matchers/base_matcher.py
@@ -42,13 +42,13 @@ class BaseMatcher(MycoMatcherClientInterface, RestCommunicationMixin):
             data = {"recommended_matches": recommended_matches}
             self._post_request(f"{self.url_prefix}/recommendations", data)
 
-    def request_offers_bids(self, filters: Dict = None):
-        self._get_request(f"{self.url_prefix}/offers-bids", {"filters": filters})
+    def request_orders(self, filters: Dict = None):
+        self._get_request(f"{self.url_prefix}/orders/", {"filters": filters})
 
-    def _on_offers_bids_response(self, data):
-        self.on_offers_bids_response(data)
+    def _on_orders_response(self, data):
+        self.on_orders_response(data)
 
-    def on_offers_bids_response(self, data):
+    def on_orders_response(self, data):
         recommendations = []
         self.submit_matches(recommendations)
 

--- a/gsy_myco_sdk/matchers/myco_matcher_client_interface.py
+++ b/gsy_myco_sdk/matchers/myco_matcher_client_interface.py
@@ -11,19 +11,19 @@ class MycoMatcherClientInterface(ABC):
     support.
     """
     @abstractmethod
-    def request_offers_bids(self, filters: Dict):
+    def request_orders(self, filters: Dict):
         """This method contains the code that queries the open offers/bids in the simulation.
 
         Returns: None
         """
 
     @abstractmethod
-    def on_offers_bids_response(self, data: Dict):
+    def on_orders_response(self, data: Dict):
         """Perform specific actions after bids/offers response is returned.
 
         Args:
             data: Contains data of the open offers/ bids in the format:
-        { "bids_offers": {market_uuid: {"offers": [...], "bids": [...]}}}
+        { "orders": {market_uuid: {"offers": [...], "bids": [...]}}}
 
         Returns: None
         """

--- a/gsy_myco_sdk/matchers/myco_matcher_client_interface.py
+++ b/gsy_myco_sdk/matchers/myco_matcher_client_interface.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List
 
-from gsy_framework.data_classes import BidOfferMatch
+from gsy_framework.data_classes import OrdersMatch
 
 
 class MycoMatcherClientInterface(ABC):
@@ -39,11 +39,11 @@ class MycoMatcherClientInterface(ABC):
         """
 
     @abstractmethod
-    def submit_matches(self, recommended_matches: List[BidOfferMatch.serializable_dict]):
+    def submit_matches(self, recommended_matches: List[OrdersMatch.serializable_dict]):
         """This method is meant to post the recommended_matches to exchange.
 
         Args:
-            recommended_matches: list of recommended trades List[BidOfferMatch.serializable_dict()
+            recommended_matches: list of recommended trades List[OrdersMatch.serializable_dict()
 
         Returns: None
         """

--- a/gsy_myco_sdk/matchers/redis_base_matcher.py
+++ b/gsy_myco_sdk/matchers/redis_base_matcher.py
@@ -67,18 +67,18 @@ class RedisBaseMatcher(MycoMatcherClientInterface):
         data = {"recommended_matches": recommended_matches}
         self.redis_db.publish(f"{self.redis_channels_prefix}/recommendations/", json.dumps(data))
 
-    def request_offers_bids(self, filters: Dict = None):
+    def request_orders(self, filters: Dict = None):
         data = {"filters": filters}
-        self.redis_db.publish(f"{self.redis_channels_prefix}/offers-bids/", json.dumps(data))
+        self.redis_db.publish(f"{self.redis_channels_prefix}/orders/", json.dumps(data))
 
     def request_area_id_name_map(self):
         channel = f"{self.simulation_id}/area-map/"
         self.redis_db.publish(channel, json.dumps({}))
 
-    def _on_offers_bids_response(self, data: Dict):
-        self.on_offers_bids_response(data=data)
+    def _on_orders_response(self, data: Dict):
+        self.on_orders_response(data=data)
 
-    def on_offers_bids_response(self, data: Dict):
+    def on_orders_response(self, data: Dict):
         recommendations = []
         self.submit_matches(recommendations)
 

--- a/gsy_myco_sdk/matching_algorithms/attributed_matching_algorithm.py
+++ b/gsy_myco_sdk/matching_algorithms/attributed_matching_algorithm.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from copy import deepcopy
 from typing import Dict, Union, List, Tuple, Iterable
 
-from gsy_framework.data_classes import BidOfferMatch
+from gsy_framework.data_classes import OrdersMatch
 from gsy_framework.matching_algorithms import BaseMatchingAlgorithm, PayAsBidMatchingAlgorithm
 
 from gsy_myco_sdk.matching_algorithms.preferred_partners_algorithm import (
@@ -38,7 +38,7 @@ class AttributedMatchingAlgorithm(BaseMatchingAlgorithm):
 
     @classmethod
     def get_matches_recommendations(
-            cls, matching_data: Dict[str, Dict]) -> List[BidOfferMatch.serializable_dict]:
+            cls, matching_data: Dict[str, Dict]) -> List[OrdersMatch.serializable_dict]:
         recommendations = []
         for market_id, time_slot_data in matching_data.items():
             for time_slot, data in time_slot_data.items():
@@ -123,7 +123,7 @@ class AttributedMatchingAlgorithm(BaseMatchingAlgorithm):
     @classmethod
     def _filter_out_consumed_orders(
             cls, bids_mapping: Dict[str, Dict], offers_mapping: Dict[str, Dict],
-            recommendations: List[BidOfferMatch.serializable_dict]) -> Tuple[Dict, Dict]:
+            recommendations: List[OrdersMatch.serializable_dict]) -> Tuple[Dict, Dict]:
         """Return bids/offers lists that are not present in the recommendations yet."""
         open_bids_mapping = deepcopy(bids_mapping)
         open_offers_mapping = deepcopy(offers_mapping)

--- a/gsy_myco_sdk/matching_algorithms/preferred_partners_algorithm.py
+++ b/gsy_myco_sdk/matching_algorithms/preferred_partners_algorithm.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from typing import Dict, List, Tuple
 
-from gsy_framework.data_classes import BidOfferMatch, BaseBidOffer, Bid, Offer
+from gsy_framework.data_classes import OrdersMatch, BaseBidOffer, Bid, Offer
 from gsy_framework.matching_algorithms import BaseMatchingAlgorithm
 from gsy_framework.matching_algorithms.requirements_validators import (
     RequirementsSatisfiedChecker)
@@ -33,7 +33,7 @@ class PreferredPartnersMatchingAlgorithm(BaseMatchingAlgorithm):
     """
     @classmethod
     def get_matches_recommendations(
-            cls, matching_data: Dict) -> List[BidOfferMatch.serializable_dict]:
+            cls, matching_data: Dict) -> List[OrdersMatch.serializable_dict]:
         recommendations = []
         for market_id, time_slot_data in matching_data.items():
             for time_slot, data in time_slot_data.items():
@@ -49,7 +49,7 @@ class PreferredPartnersMatchingAlgorithm(BaseMatchingAlgorithm):
             cls, market_id: str,
             time_slot: str,
             bids: List[Bid.serializable_dict],
-            offers: List[Offer.serializable_dict]) -> List[BidOfferMatch.serializable_dict]:
+            offers: List[Offer.serializable_dict]) -> List[OrdersMatch.serializable_dict]:
         """
         This is a variant of the PAB algorithm, it works as following:
             1. Iterate over bids
@@ -90,7 +90,7 @@ class PreferredPartnersMatchingAlgorithm(BaseMatchingAlgorithm):
                         selected_energy = min(bid_required_energy, offer_required_energy)
                         already_selected_offers.add(offer.get("id"))
                         orders_pair = (
-                            BidOfferMatch(
+                            OrdersMatch(
                                 market_id=market_id,
                                 bids=[bid], offers=[offer],
                                 selected_energy=selected_energy,

--- a/gsy_myco_sdk/matching_algorithms/preferred_partners_algorithm.py
+++ b/gsy_myco_sdk/matching_algorithms/preferred_partners_algorithm.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from typing import Dict, List, Tuple
 
-from gsy_framework.data_classes import OrdersMatch, BaseBidOffer, Bid, Offer
+from gsy_framework.data_classes import OrdersMatch, BaseOrder, Bid, Offer
 from gsy_framework.matching_algorithms import BaseMatchingAlgorithm
 from gsy_framework.matching_algorithms.requirements_validators import (
     RequirementsSatisfiedChecker)
@@ -155,7 +155,7 @@ class PreferredPartnersMatchingAlgorithm(BaseMatchingAlgorithm):
 
     @classmethod
     def _get_required_energy_and_rate_from_order(
-            cls, order: BaseBidOffer.serializable_dict,
+            cls, order: BaseOrder.serializable_dict,
             order_requirement: Dict) -> Tuple[float, float]:
         """Determine the energy and clearing rate based on an order + its requirement.
 

--- a/gsy_myco_sdk/setups/myco_matcher.py
+++ b/gsy_myco_sdk/setups/myco_matcher.py
@@ -21,10 +21,10 @@ class MycoMatcher(base_matcher):
         pass
 
     def on_tick(self, data):
-        self.request_offers_bids(filters={})
+        self.request_orders(filters={})
 
-    def on_offers_bids_response(self, data):
-        matching_data = data.get("bids_offers")
+    def on_orders_response(self, data):
+        matching_data = data.get("orders")
         if not matching_data:
             return
         recommendations = AttributedMatchingAlgorithm.get_matches_recommendations(

--- a/gsy_myco_sdk/websocket_device.py
+++ b/gsy_myco_sdk/websocket_device.py
@@ -8,7 +8,7 @@ class WebsocketMessageReceiver:
         self.client = rest_client
 
     def _handle_event_message(self, message):
-        """Available events: market, tick, finish, offers_bids_response, matched_recommendations_response.
+        """Available events: market, tick, finish, orders_response, matched_recommendations_response.
 
         Args:
             message: Received websocket message

--- a/integration_tests/build_test_containers.sh
+++ b/integration_tests/build_test_containers.sh
@@ -8,7 +8,7 @@ if [[ "$(docker images -q ${GSY_E_IMAGE_TAG} 2> /dev/null)" == "" ]]; then
   echo "Building gsy_e image ..." && \
   rm -rf tests/gsy-e && \
   cd tests/ && \
-  git clone https://github.com/gridsingularity/gsy-e.git && \
+  git clone -b rename-bids-offers https://github.com/gridsingularity/gsy-e.git && \
   cd gsy-e && \
   docker build -t ${GSY_E_IMAGE_TAG} . && \
   cd ../ && \

--- a/integration_tests/steps/myco.py
+++ b/integration_tests/steps/myco.py
@@ -48,7 +48,7 @@ def step_impl(context):
 
 @then("all events handler are called")
 def step_impl(context):
-    assert context.matcher.called_events == {"market_cycle", "tick", "offers_bids_response",
+    assert context.matcher.called_events == {"market_cycle", "tick", "orders_response",
                                              "event_or_response", "match", "finish",
                                              "on_area_map_response"}
 

--- a/integration_tests/test_redis_myco_matcher.py
+++ b/integration_tests/test_redis_myco_matcher.py
@@ -20,12 +20,12 @@ class TestRedisMycoMatcher(RedisBaseMatcher):
     def on_tick(self, data):
         self.called_events.add("tick")
         logging.info("Tick")
-        self.request_offers_bids(filters={})
+        self.request_orders(filters={})
 
-    def on_offers_bids_response(self, data):
-        self.called_events.add("offers_bids_response")
+    def on_orders_response(self, data):
+        self.called_events.add("orders_response")
         recommendations = PayAsBidMatchingAlgorithm.get_matches_recommendations(
-            data.get("bids_offers"))
+            data.get("orders"))
         self.submit_matches(recommendations)
 
     def on_finish(self, data):

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ commands =
 	pip install -e .
 	pip install -r requirements/tests.txt
 	flake8
+	pip install git+https://github.com/gridsingularity/gsy-framework.git@rename-bids-offers
 	coverage run -m pytest unit_tests/ --random-order {posargs:tests}
 	coverage combine
 	coverage xml

--- a/unit_tests/test_matching_algorithms/test_preferred_partners_matching_algorithm.py
+++ b/unit_tests/test_matching_algorithms/test_preferred_partners_matching_algorithm.py
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import uuid
 from typing import Optional
 
-from gsy_framework.data_classes import Offer, BidOfferMatch, Bid
+from gsy_framework.data_classes import Offer, OrdersMatch, Bid
 from pendulum import DateTime
 
 from myco_api_client.matching_algorithms.preferred_partners_algorithm import (
@@ -73,11 +73,11 @@ class TestPreferredPartnersMatchingAlgorithm:
         }}}
         assert PreferredPartnersMatchingAlgorithm.get_matches_recommendations(
             data) == [
-                   BidOfferMatch(bids=[bid], offers=[offer],
-                                 market_id="market",
-                                 trade_rate=bid["energy_rate"],
-                                 selected_energy=30,
-                                 time_slot="2021-10-06T12:00").serializable_dict()]
+                   OrdersMatch(bids=[bid], offers=[offer],
+                               market_id="market",
+                               trade_rate=bid["energy_rate"],
+                               selected_energy=30,
+                               time_slot="2021-10-06T12:00").serializable_dict()]
 
     def test_get_energy_and_clearing_rate(self):
         offer = self.offer_factory().serializable_dict()


### PR DESCRIPTION
Adapt to changes in the [GSY-framework](https://github.com/gridsingularity/gsy-framework/pull/296)
Update the `bids-offers/` redis channel to be `orders/`
Rename the events callbacks names