### PR TITLE
GSYE-205: deepcopy the orders passed as recommendations

### DIFF
--- a/gsy_myco_sdk/matching_algorithms/preferred_partners_algorithm.py
+++ b/gsy_myco_sdk/matching_algorithms/preferred_partners_algorithm.py
@@ -206,7 +206,7 @@ class PreferredPartnersMatchingAlgorithm(BaseMatchingAlgorithm):
                 recommendation = BidOfferMatch(
                     market_id=market_id,
                     time_slot=time_slot,
-                    bid=bid, offer=offer,
+                    bid=deepcopy(bid), offer=deepcopy(offer),
                     selected_energy=selected_energy,
                     trade_rate=bid_required_clearing_rate,
                     matching_requirements={


### PR DESCRIPTION
The problem was due to the fact that we were passing the actual objects to the recommendation and then deducting the selected energy below. However, here we're still using the same pointer to the orders dicts and thus we're changing the already created recommendations.
The mentioned line is 
```python
bid_requirement["energy"] -= selected_energy
```