### PR TITLE
GSYE-156: log market type name when receiving recommendations response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# iSort configuration
+.isort.cfg

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ by overriding the corresponding methods.
 The constructor of the API class can connect and register automatically to a running collaboration:
 - `REST`
     ```
-    matching_client = BaseMatcher()
+    matching_client = RestBaseMatcher()
     ```
 - `LOCAL`
     ```
@@ -104,7 +104,7 @@ The constructor of the API class can connect and register automatically to a run
 
     ```python
     ```python
-      from gsy_myco_sdk.matchers.base_matcher import RestBaseMatcher
+      from gsy_myco_sdk.matchers.rest_base_matcher import RestBaseMatcher
       matching_client = RestBaseMatcher()
       matching_client.request_offers_bids(filters={})
       ```

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ the API of the GSy Exchange external connections in order to be able to dynamica
 electrical grid, query the open bids/offers and post trading recommendations back to GSy Exchange.
 
 For local test runs of GSy Exchange Redis (https://redis.io/) is used as communication protocol.
-In the following commands for the local test run are marked with `LOCAL`. 
+In the following commands for the local test run are marked with `LOCAL`.
 
 For communication with collaborations or canary networks on https://d3a.io, a RESTful API is used.
-In the following commands for the connection via the REST API are marked with `REST`. 
+In the following commands for the connection via the REST API are marked with `REST`.
 
 ## Installation Instructions
 
@@ -47,7 +47,7 @@ The following parameters can be set via the CLI:
 - `domain-name` --> GSy Exchange domain URL
 - `web-socket` --> GSy Exchange websocket URL
 - `simulation-id` --> UUID of the collaboration or Canary Network (CN)
-- `run-on-redis` --> This flag can be set for local testing of the API client, where no user authentication is required. 
+- `run-on-redis` --> This flag can be set for local testing of the API client, where no user authentication is required.
   For that, a locally running redis server and GSy Exchange simulation are needed.
 #### Examples
 - For local testing of the API client:
@@ -56,13 +56,13 @@ The following parameters can be set via the CLI:
   ```
 - For testing your api client script on remote server hosting GSy Exchange's collaboration/CNs.
     - If user's client script resides on `gsy_myco_sdk/setups`
-    
+
   ```
     gsy-myco-sdk run -u <username> -p <password> --setup myco_matcher -s <simulation-uuid> ...
     ```
-    
+
     - If user's client script resides on a different directory, then its path needs to be set via `--base-setup-path`
-    
+
   ```
     gsy-myco-sdk run -u <username> -p <password> --base-setup-path <absolute/relative-path-to-your-client-script> --setup <name-of-your-script> ...
     ```
@@ -71,8 +71,8 @@ The following parameters can be set via the CLI:
 
 
 ### Events
-In order to facilitate offer and bid management and scheduling, 
-the client will get notified via events. 
+In order to facilitate offer and bid management and scheduling,
+the client will get notified via events.
 It is possible to capture these events and perform operations as a reaction to them
 by overriding the corresponding methods.
 - when a new market cycle is triggered the `on_market_cycle` method is called
@@ -91,7 +91,7 @@ The constructor of the API class can connect and register automatically to a run
     matching_client = BaseMatcher()
     ```
 - `LOCAL`
-    ``` 
+    ```
     matching_client = RedisBaseMatcher()
     ```
 ---
@@ -100,29 +100,29 @@ The constructor of the API class can connect and register automatically to a run
 
 `Matcher` instances provide methods that can simplify specific operations. Below we have a demo:
 
-- Fire a request to get filtered open bids/offers in the simulation: 
+- Fire a request to get filtered open bids/offers in the simulation:
 
     ```python
     ```python
-      from gsy_myco_sdk.matchers.base_matcher import BaseMatcher
-      matching_client = BaseMatcher()
-      matching_client.request_offers_bids(filters={}) 
+      from gsy_myco_sdk.matchers.base_matcher import RestBaseMatcher
+      matching_client = RestBaseMatcher()
+      matching_client.request_offers_bids(filters={})
       ```
     ```
-    
+
     Supported filters include:
-    - `markets`: list of market ids, only fetch bids/offers in these markets (If not provided, all markets are included). 
+    - `markets`: list of market ids, only fetch bids/offers in these markets (If not provided, all markets are included).
     - `energy_type`: energy type of offers to be returned.
-          
+
     The bids_offers response can be received in the method named `on_offers_bids_response`, this one can be overridden to decide the recommendations algorithm and fires a call to submit_matches()
 
-  
+
 - Posts the trading bid/offer pairs recommendations back to GSy Exchange, can be called from the overridden on_offers_bids_response:
 
     ```python
     def on_offers_bids_response(self, data):
       """
-      Posted recommendations should be in the format: 
+      Posted recommendations should be in the format:
       [BidOfferMatch.serializable_dict(), BidOfferMatch.serializable_dict()]
       """
       bids_offers = data.get("bids_offers")

--- a/gsy_myco_sdk/matchers/__init__.py
+++ b/gsy_myco_sdk/matchers/__init__.py
@@ -1,6 +1,6 @@
 __all__ = [
-    "BaseMatcher",
+    "RestBaseMatcher",
     "RedisBaseMatcher"
 ]
-from .base_matcher import BaseMatcher
+from .rest_base_matcher import RestBaseMatcher
 from .redis_base_matcher import RedisBaseMatcher

--- a/gsy_myco_sdk/matchers/base_matcher.py
+++ b/gsy_myco_sdk/matchers/base_matcher.py
@@ -7,11 +7,10 @@ from gsy_framework.client_connections.utils import (
     RestCommunicationMixin, retrieve_jwt_key_from_server)
 from gsy_framework.client_connections.websocket_connection import WebsocketThread
 
-from gsy_myco_sdk.matchers.myco_matcher_client_interface import MycoMatcherClientInterface
 from gsy_myco_sdk.constants import MAX_WORKER_THREADS
+from gsy_myco_sdk.matchers.myco_matcher_client_interface import MycoMatcherClientInterface
 from gsy_myco_sdk.utils import (
-    simulation_id_from_env, domain_name_from_env, websocket_domain_name_from_env,
-    )
+    domain_name_from_env, simulation_id_from_env, websocket_domain_name_from_env)
 from gsy_myco_sdk.websocket_device import WebsocketMessageReceiver
 
 
@@ -47,10 +46,10 @@ class BaseMatcher(MycoMatcherClientInterface, RestCommunicationMixin):
     def request_offers_bids(self, filters: Dict = None):
         self._get_request(f"{self.url_prefix}/offers-bids", {"filters": filters})
 
-    def _on_offers_bids_response(self, data):
+    def _on_offers_bids_response(self, data: Dict):
         self.on_offers_bids_response(data)
 
-    def on_offers_bids_response(self, data):
+    def on_offers_bids_response(self, data: Dict):
         recommendations = []
         self.submit_matches(recommendations)
 

--- a/gsy_myco_sdk/matchers/myco_matcher_logger.py
+++ b/gsy_myco_sdk/matchers/myco_matcher_logger.py
@@ -7,6 +7,9 @@ from gsy_framework.constants_limits import DEFAULT_PRECISION
 from tabulate import tabulate
 
 
+LOGGER = logging.getLogger(__name__)
+
+
 class MycoMatcherLogger:
     """Custom logger used by instances of Myco matchers."""
 
@@ -26,7 +29,7 @@ class MycoMatcherLogger:
         recommendations = data["recommendations"]
         if not recommendations:
             return
-        logging.info("Length of recommendations: %s", len(recommendations))
+        LOGGER.info("Length of recommendations: %s", len(recommendations))
         recommendations_table = []
         recommendations_table_headers = [
             "#",
@@ -67,5 +70,6 @@ class MycoMatcherLogger:
                 index += 1
                 orders_cache.add(offer_data)
                 orders_cache.add(bid_data)
-        logging.info("\n%s", tabulate(recommendations_table, recommendations_table_headers,
-                                      tablefmt="fancy_grid"))
+        LOGGER.info(
+            "\n%s", tabulate(
+                recommendations_table, recommendations_table_headers, tablefmt="fancy_grid"))

--- a/gsy_myco_sdk/matchers/myco_matcher_logger.py
+++ b/gsy_myco_sdk/matchers/myco_matcher_logger.py
@@ -1,0 +1,71 @@
+"""Module for the logger used by Myco matcher classes."""
+
+import logging
+from typing import Dict
+
+from gsy_framework.constants_limits import DEFAULT_PRECISION
+from tabulate import tabulate
+
+
+class MycoMatcherLogger:
+    """Custom logger used by instances of Myco matchers."""
+
+    @staticmethod
+    def log_recommendations_response(markets: Dict, data: Dict) -> None:
+        """Log the response data of recommendations sent to the clearing mechanism.
+
+        Args:
+            markets: a dictionary with the following structure:
+                {
+                    "<market-id>": {
+                        "<time-slot-1>": {"market_type_name": "<market-type-name>"}
+                        "<time-slot-2>": {"market_type_name": "<market-type-name>"}
+                    }
+                }
+        """
+        recommendations = data["recommendations"]
+        if not recommendations:
+            return
+        logging.info("Length of recommendations: %s", len(recommendations))
+        recommendations_table = []
+        recommendations_table_headers = [
+            "#",
+            "Market Type Name",
+            "Buyer", "Seller",
+            "Bid kWh", "Offer kWh", "Status", "Message"]
+
+        # Orders can get forwarded to higher/lower markets
+        # In order not to log all propagations of the same orders, a workaround
+        # would be to cache the already logged orders' attributes that do not change when forwarded
+        orders_cache = set()
+        index = 1
+
+        for recommendation in recommendations:
+            cached_market_info = markets.get(recommendation["market_id"])
+            time_slot = recommendation["time_slot"]
+            market_type_name = cached_market_info[time_slot][
+                "market_type_name"] if cached_market_info else "Unknown"
+
+            bid = recommendation["bid"]
+            offer = recommendation["offer"]
+            offer_data = (f"{round(offer['energy'], DEFAULT_PRECISION)}-"
+                          f"{round(offer['original_price'], DEFAULT_PRECISION)}-"
+                          f"{offer['seller_origin_id']}-{offer['time_slot']}")
+            bid_data = (f"{round(bid['energy'], DEFAULT_PRECISION)}-"
+                        f"{round(bid['original_price'], DEFAULT_PRECISION)}-"
+                        f"{bid['buyer_origin_id']}-{bid['time_slot']}")
+            if offer_data not in orders_cache or bid_data not in orders_cache:
+                recommendations_table.append([
+                    index,
+                    market_type_name,
+                    bid.get("buyer_origin"),
+                    offer.get("seller_origin"),
+                    bid.get("energy"),
+                    offer.get("energy"),
+                    recommendation["status"],
+                    recommendation.get("message")])
+                index += 1
+                orders_cache.add(offer_data)
+                orders_cache.add(bid_data)
+        logging.info("\n%s", tabulate(recommendations_table, recommendations_table_headers,
+                                      tablefmt="fancy_grid"))

--- a/gsy_myco_sdk/matchers/rest_base_matcher.py
+++ b/gsy_myco_sdk/matchers/rest_base_matcher.py
@@ -14,7 +14,7 @@ from gsy_myco_sdk.utils import (
 from gsy_myco_sdk.websocket_device import WebsocketMessageReceiver
 
 
-class BaseMatcher(MycoMatcherClientInterface, RestCommunicationMixin):
+class RestBaseMatcher(MycoMatcherClientInterface, RestCommunicationMixin):
     """Handle order matching via rest connection."""
     def __init__(self, simulation_id=None, domain_name=None, websocket_domain_name=None):
         self.simulation_id = simulation_id if simulation_id else simulation_id_from_env()

--- a/gsy_myco_sdk/setups/myco_matcher.py
+++ b/gsy_myco_sdk/setups/myco_matcher.py
@@ -3,13 +3,13 @@ import os
 from time import sleep
 
 from gsy_myco_sdk.matchers import RedisBaseMatcher
-from gsy_myco_sdk.matchers.base_matcher import BaseMatcher
+from gsy_myco_sdk.matchers.rest_base_matcher import RestBaseMatcher
 from gsy_myco_sdk.matching_algorithms import AttributedMatchingAlgorithm
 
 if os.environ["MYCO_CLIENT_RUN_ON_REDIS"] == "true":
     base_matcher = RedisBaseMatcher
 else:
-    base_matcher = BaseMatcher
+    base_matcher = RestBaseMatcher
 
 
 class MycoMatcher(base_matcher):

--- a/gsy_myco_sdk/utils.py
+++ b/gsy_myco_sdk/utils.py
@@ -1,9 +1,4 @@
-import logging
 import os
-from typing import Dict
-
-from gsy_framework.constants_limits import DEFAULT_PRECISION
-from tabulate import tabulate
 
 from gsy_myco_sdk.constants import (
     DEFAULT_DOMAIN_NAME, DEFAULT_WEBSOCKET_DOMAIN, MYCO_CLIENT_SIMULATION_ID)
@@ -22,40 +17,3 @@ def websocket_domain_name_from_env():
 def simulation_id_from_env():
     """Retrieve the ID of the simulation that the Myco should target from the env variables."""
     return os.environ.get("MYCO_CLIENT_SIMULATION_ID", MYCO_CLIENT_SIMULATION_ID)
-
-
-def log_recommendations_response(data: Dict) -> None:
-    """Log the response data of recommendations sent to the clearing mechanism."""
-    recommendations = data["recommendations"]
-    if not recommendations:
-        return
-    logging.info("Length of recommendations: %s", len(recommendations))
-    recommendations_table = []
-    recommendations_table_headers = [
-        "#", "Buyer", "Seller",
-        "Bid kWh", "Offer kWh", "Status", "Message"]
-
-    # Orders can get forwarded to higher/lower markets
-    # In order not to log all propagations of the same orders, a workaround
-    # would be to cache the already logged orders' attributes that do not change when forwarded
-    orders_cache = set()
-    index = 1
-    for recommendation in recommendations:
-        bid = recommendation["bid"]
-        offer = recommendation["offer"]
-        offer_data = (f"{round(offer['energy'], DEFAULT_PRECISION)}-"
-                      f"{round(offer['original_price'], DEFAULT_PRECISION)}-"
-                      f"{offer['seller_origin_id']}-{offer['time_slot']}")
-        bid_data = (f"{round(bid['energy'], DEFAULT_PRECISION)}-"
-                    f"{round(bid['original_price'], DEFAULT_PRECISION)}-"
-                    f"{bid['buyer_origin_id']}-{bid['time_slot']}")
-        if offer_data not in orders_cache or bid_data not in orders_cache:
-            recommendations_table.append(
-                [index, bid.get("buyer_origin"), offer.get("seller_origin"),
-                 bid.get("energy"), offer.get("energy"), recommendation["status"],
-                 recommendation.get("message")])
-            index += 1
-            orders_cache.add(offer_data)
-            orders_cache.add(bid_data)
-    logging.info("\n%s", tabulate(recommendations_table, recommendations_table_headers,
-                                  tablefmt="fancy_grid"))

--- a/gsy_myco_sdk/utils.py
+++ b/gsy_myco_sdk/utils.py
@@ -5,19 +5,22 @@ from typing import Dict
 from gsy_framework.constants_limits import DEFAULT_PRECISION
 from tabulate import tabulate
 
-from gsy_myco_sdk.constants import DEFAULT_DOMAIN_NAME, DEFAULT_WEBSOCKET_DOMAIN, \
-    MYCO_CLIENT_SIMULATION_ID
+from gsy_myco_sdk.constants import (
+    DEFAULT_DOMAIN_NAME, DEFAULT_WEBSOCKET_DOMAIN, MYCO_CLIENT_SIMULATION_ID)
 
 
 def domain_name_from_env():
+    """Retrieve the Myco domain name from the environment variables."""
     return os.environ.get("MYCO_CLIENT_DOMAIN_NAME", DEFAULT_DOMAIN_NAME)
 
 
 def websocket_domain_name_from_env():
+    """Retrieve the Myco websocket's domain name from the environment variables."""
     return os.environ.get("MYCO_CLIENT_WEBSOCKET_DOMAIN_NAME", DEFAULT_WEBSOCKET_DOMAIN)
 
 
 def simulation_id_from_env():
+    """Retrieve the ID of the simulation that the Myco should target from the env variables."""
     return os.environ.get("MYCO_CLIENT_SIMULATION_ID", MYCO_CLIENT_SIMULATION_ID)
 
 


### PR DESCRIPTION
We want to log the market type name (Settlement/Spot/Future) when we receive the response from the exchange regarding the received recommendations (`match` event, `_on_matched_recommendations_response()` method).

- Implemented cache in the Redis/Rest matchers. This cache stores the information we receive from the exchange about the markets during the `_on_offers_bids_response()` callback.
- use this cached information when we receive the match event response from the exchange (in the _on_matched_recommendations_response()` callback)
- Since this functionality is shared between Redis/Rest matchers, I've put it into a separate logger helper class, following the single responsibility principle.
- I've also renamed the `BaseMatcher` to `RestBaseMatcher` for consistency with the `RedisBaseMatcher`. Actually, I think it would be good to just call them `Rest/RedisMatcher` (without the "Base" part).