### PR TITLE
TESTS-138: Template PR message not showing when PR is created

### DIFF
--- a/.github/workflows/myco_ci.yaml
+++ b/.github/workflows/myco_ci.yaml
@@ -48,4 +48,4 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           INTEGRATION_TESTS_REPO: https://gsydev:${{ secrets.GSYDEV_TOKEN }}@github.com/gridsingularity/gsy-backend-integration-tests.git
-          INTEGRATION_TESTS_BRANCH: ${{ steps.parse_branch.outputs.INTEGRATION_TESTS_BRANCH }}
+          INTEGRATION_TESTS_BRANCH: ${{ steps.validated_branch.outputs.INTEGRATION_TESTS_BRANCH }}

--- a/.github/workflows/myco_ci.yaml
+++ b/.github/workflows/myco_ci.yaml
@@ -23,8 +23,15 @@ jobs:
         env:
           prBody: ${{ steps.PR.outputs.pr_body }}
         run: |
-          echo "::set-output name=INTEGRATION_TESTS_BRANCH::$(echo -e $prBody | sed -n 's/.*\*\*INTEGRATION_TESTS_BRANCH\*\*=\([^ ]*\).*/\1/p')"
+          echo "::set-output name=PARSED_INTEGRATION_TESTS_BRANCH::$(echo -e $prBody | sed -n 's/.*\*\*INTEGRATION_TESTS_BRANCH\*\*=\([^ ]*\).*/\1/p')"
         id: parse_branch
+
+      - name: Validate parsed branch
+        env:
+          PARSED_INTEGRATION_TESTS_BRANCH: ${{ steps.parse_branch.outputs.PARSED_INTEGRATION_TESTS_BRANCH }}
+        run: |
+          echo "::set-output name=INTEGRATION_TESTS_BRANCH::${PARSED_INTEGRATION_TESTS_BRANCH:-'master'}"
+        id: validated_branch
 
       - uses: actions/checkout@v2
       - name: Setup Python


### PR DESCRIPTION
## Reason for the proposed changes

Recently, a PR template message file was created on gsy-e, gsy-e-sdk, gsy-myco-sdk and gsy-web repositories including a line which specifies wether a particular branch from GBIT repository should be called. 

## Proposed changes

- Fix for the template to load on a new PR to base branch.

- Default cloning branch for GBIT repo implementation, considering the possibility that (by mistake) no GBIT cloning branch is specified.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
