### PR TITLE
GSYE-274: Make --setup CLI option required with no default value.

### DIFF
--- a/gsy_myco_sdk/cli.py
+++ b/gsy_myco_sdk/cli.py
@@ -62,7 +62,7 @@ def main(log_level):
 @main.command()
 @click.option("-b", "--base-setup-path", default=None, type=str,
               help="Accept absolute or relative path for matcher script")
-@click.option("--setup", "setup_module_name", default="base_matcher_setup",
+@click.option("--setup", "setup_module_name", required=True,
               help="Setup module of matcher script. Available modules: [{}]".format(
                   ", ".join(_setup_modules)))
 @click.option("-u", "--username", default=None, type=str, help="GSy Exchange username")


### PR DESCRIPTION
## Reason for the proposed changes
[GSYE-274](https://gridsingularity.atlassian.net/browse/GSYE-274) as requested by @Hassan754 

## Proposed changes
- Make --setup CLI option required with no default value.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
<!--- If needed, choose which gsy-e branch should be used to build docker image to execute integration tests.-->
**GSY_E_TARGET_BRANCH**=master
