### PR TITLE
Add on_area_map_response method to myco_matcher

### DIFF
--- a/gsy_myco_sdk/setups/myco_matcher.py
+++ b/gsy_myco_sdk/setups/myco_matcher.py
@@ -1,10 +1,11 @@
-import logging
 import os
 from time import sleep
 
 from gsy_myco_sdk.matchers import RedisBaseMatcher
 from gsy_myco_sdk.matchers.base_matcher import BaseMatcher
 from gsy_myco_sdk.matching_algorithms import AttributedMatchingAlgorithm
+
+from gsy_myco_sdk.utils import log_recommendations_response
 
 if os.environ["MYCO_CLIENT_RUN_ON_REDIS"] == "true":
     base_matcher = RedisBaseMatcher
@@ -16,31 +17,40 @@ class MycoMatcher(base_matcher):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.is_finished = False
+        self.request_area_id_name_map()
+        self.id_list = []
+
+    def on_area_map_response(self, data):
+        market_list = ["Community"]
+        for market in market_list:
+            for market_id, name in data["area_mapping"].items():
+                if name == market:
+                    self.id_list.append(market_id)
 
     def on_market_cycle(self, data):
         pass
 
     def on_tick(self, data):
-        self.request_offers_bids(filters={})
+        self.request_offers_bids(filters={"markets": self.id_list})
 
     def on_offers_bids_response(self, data):
         matching_data = data.get("bids_offers")
         if not matching_data:
             return
         recommendations = AttributedMatchingAlgorithm.get_matches_recommendations(
-            matching_data)
+            matching_data
+        )
         if recommendations:
-            logging.info("Submitting %s recommendations.", len(recommendations))
             self.submit_matches(recommendations)
+
+    def on_matched_recommendations_response(self, data):
+        log_recommendations_response(data)
+
+    def on_event_or_response(self, data):
+        pass
 
     def on_finish(self, data):
         self.is_finished = True
-
-    def on_matched_recommendations_response(self, data):
-        pass
-
-    def on_event_or_response(self, data):
-        logging.debug("Event arrived %s", data)
 
 
 matcher = MycoMatcher()


### PR DESCRIPTION
… markets from which they want to request bids/offers from by directly inputting the market name (e.g., "Community") instead of their IDs. The on_area_map_response function populates the id_list with the IDs of the associated areas, given their names. This list of IDs then goes to the filtering function request_offers_bids .

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
<!--- If needed, choose which gsy-e branch should be used to build docker image to execute integration tests.-->
**GSY_E_TARGET_BRANCH**=master
