### PR TITLE
GSYE-364: Fix backports-entry-points-selectable==1.1.0 installation error

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ attrs==21.2.0
     # via
     #   gsy-framework
     #   jsonschema
-backports-entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.0
     # via
     #   gsy-framework
     #   virtualenv

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -14,7 +14,7 @@ attrs==21.2.0
     #   gsy-framework
     #   jsonschema
     #   pytest
-backports-entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.0
     # via
     #   -r requirements/base.txt
     #   gsy-framework


### PR DESCRIPTION
## Proposed Changes:
- Fix dependency name for backports-entry-points-selectable


<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
<!--- If needed, choose which gsy-e branch should be used to build docker image to execute integration tests.-->
**GSY_E_TARGET_BRANCH**=bug/GSYE-364
